### PR TITLE
librecuda: checking file device descriptor before using in memMapToCpu

### DIFF
--- a/src/librecuda.cpp
+++ b/src/librecuda.cpp
@@ -314,10 +314,14 @@ memMapToCpu(LibreCUcontext ctx, NvHandle memoryHandle, size_t size, NvU64 cpuVir
     int device_fd;
     if (isSystemAlloc) {
         device_fd = open("/dev/nvidiactl", O_RDWR | O_CLOEXEC);
+        if (device_fd < 0)
+            LIBRECUDA_FAIL(LIBRECUDA_ERROR_INVALID_DEVICE);
     } else {
         std::string device_file = getDeviceFile(ctx->device);
 
         device_fd = open(device_file.c_str(), O_RDWR | O_CLOEXEC);
+        if (device_fd < 0)
+            LIBRECUDA_FAIL(LIBRECUDA_ERROR_INVALID_DEVICE);
         nv_ioctl_register_fd_t params{
                 .ctl_fd=fd_ctl
         };

--- a/src/librecuda.cpp
+++ b/src/librecuda.cpp
@@ -314,14 +314,12 @@ memMapToCpu(LibreCUcontext ctx, NvHandle memoryHandle, size_t size, NvU64 cpuVir
     int device_fd;
     if (isSystemAlloc) {
         device_fd = open("/dev/nvidiactl", O_RDWR | O_CLOEXEC);
-        if (device_fd < 0)
-            LIBRECUDA_FAIL(LIBRECUDA_ERROR_INVALID_DEVICE);
+        LIBRECUDA_VALIDATE(fd_ctl != -1, LIBRECUDA_ERROR_INVALID_DEVICE);
     } else {
         std::string device_file = getDeviceFile(ctx->device);
 
         device_fd = open(device_file.c_str(), O_RDWR | O_CLOEXEC);
-        if (device_fd < 0)
-            LIBRECUDA_FAIL(LIBRECUDA_ERROR_INVALID_DEVICE);
+        LIBRECUDA_VALIDATE(device_fd != -1, LIBRECUDA_ERROR_INVALID_DEVICE);
         nv_ioctl_register_fd_t params{
                 .ctl_fd=fd_ctl
         };


### PR DESCRIPTION
@mikex86, added correct check before use, it can return -1 according to POSIX documentation.