### PR TITLE
use CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ else ()
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif ()
 
-if (NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/ELFIO/elfio)
+if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ELFIO/elfio)
     message("-- ELFIO not found, fetching ELFIO...")
     execute_process(COMMAND git submodule update --init)
     add_subdirectory(third_party/ELFIO)

--- a/tests/write_float/CMakeLists.txt
+++ b/tests/write_float/CMakeLists.txt
@@ -8,4 +8,4 @@ target_link_libraries(
         driverapi
 )
 
-configure_file(${CMAKE_SOURCE_DIR}/tests/write_float/write_float.cubin ${CMAKE_BINARY_DIR}/bin COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/write_float.cubin ${CMAKE_BINARY_DIR}/bin COPYONLY)


### PR DESCRIPTION
When trying to link to a project, using CMAKE_SOURCE_DIR would be substituted by the top project directory